### PR TITLE
Downgrade to go v1.18

### DIFF
--- a/bids-hook.go
+++ b/bids-hook.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"path"
 )
 
 var (
@@ -204,7 +205,9 @@ type job struct {
 
 // postPending posts a "pending" (yellow dot) commit status to Gitea
 func (j job) postPending(ctx context.Context) error {
-	url := giteaApiUrl.JoinPath("repos", j.user, j.repo, "statuses", j.commit)
+	url := *giteaApiUrl
+	path := path.Join(giteaApiUrl.Path, "repos", j.user, j.repo, "statuses", j.commit)
+	url.Path = path
 
 	reqBody, err := json.Marshal(map[string]string{
 		"context":     "bids-validator",

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/neuropoly/bids-hook
 
-go 1.19
+go 1.18
 
 require github.com/google/uuid v1.3.0


### PR DESCRIPTION
Gitea is built against golang 1.18, and Ubuntu LTS only has up to 1.18, so it will be easiest if bids-hook is too.